### PR TITLE
Bugfix/es pipeline fix

### DIFF
--- a/start-elastic-stack.sh
+++ b/start-elastic-stack.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-sudo sysctl -w vm.max_map_count=262144
-docker-compose up
+sudo sysctl -w vm.max_map_count=262144 && docker-compose up

--- a/witms/pipelines.py
+++ b/witms/pipelines.py
@@ -34,6 +34,11 @@ class ElasticSearchPipeline:
             helpers.bulk(self.client, self.items_buffer)
 
     def process_item(self, item, spider):
+        # We need to check if an item has any of a few properties in order to check
+        # whether the item is really a news article
+        any_required_properties = {"publish_timestamp", "update_timestamp", "authors"}
+        if not any([item.get[prop] for prop in any_required_properties]):
+            return item
         action = {"_index": self.es_index, "_source": dict(item)}
         self.items_buffer.append(action)
         if len(self.items_buffer) >= self.buffer_size:

--- a/witms/pipelines.py
+++ b/witms/pipelines.py
@@ -27,6 +27,10 @@ class ElasticSearchPipeline:
     def open_spider(self, spider):
         self.client = Elasticsearch(hosts=self.es_hosts)
 
+    def close_spider(self, spider):
+        if len(self.items_buffer) > 0:
+            helpers.bulk(self.client, self.items_buffer)
+
     def process_item(self, item, spider):
         action = {"_index": self.es_index, "_source": dict(item)}
         self.items_buffer.append(action)

--- a/witms/settings.py
+++ b/witms/settings.py
@@ -13,3 +13,4 @@ ITEM_PIPELINES = {
 
 ES_INDEX_NAME = "news-index"
 ES_HOSTS = "localhost"
+ES_BUFFER_SIZE = 1000


### PR DESCRIPTION
This was initially to fix the item buffer not being flushed when the crawling was finished, leaving a few items unprocessed. I also added in a check to prevent non-article items being pushed to the ES index (not the most elegant solution, but it works) and turned the buffer size into a setting, rather than a local constant.