### PR TITLE
Add pipeline to filter out old news

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -491,6 +491,17 @@ wcwidth = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.1"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
@@ -699,7 +710,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9"
-content-hash = "8b71867525c705669bc5292d60ba7222b4a89084b8f360e9366a4d16562f1490"
+content-hash = "c3464e071e6f90e3f61bf22f4ee67c51b6cca7238a86bbf6db47a74bdc68425c"
 
 [metadata.files]
 appdirs = [
@@ -985,6 +996,10 @@ pypydispatcher = [
 pytest = [
     {file = "pytest-5.2.0-py3-none-any.whl", hash = "sha256:13c1c9b22127a77fc684eee24791efafcef343335d855e3573791c68588fe1a5"},
     {file = "pytest-5.2.0.tar.gz", hash = "sha256:d8ba7be9466f55ef96ba203fc0f90d0cf212f2f927e69186e1353e30bc7f62e5"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
+    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Matheus Westhelle <matheus.westhelle@gmail.com>"]
 python = "3.9"
 Scrapy = "2.4.1"
 elasticsearch = "7.11.0"
+python-dateutil = "2.8.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "5.2"

--- a/witms/settings.py
+++ b/witms/settings.py
@@ -10,8 +10,15 @@ USER_AGENT = (
 
 CONCURRENT_REQUESTS = 32
 
-ITEM_PIPELINES = {"witms.pipelines.RequiredPropsPipeline": 300}
+ITEM_PIPELINES = {
+    "witms.pipelines.RequiredPropsPipeline": 300,
+    "witms.pipelines.OldestPeriodPipeline": 400,
+}
+
+FEED_EXPORT_ENCODING = "utf-8"
 
 ES_INDEX_NAME = "news-index"
 ES_HOSTS = "localhost"
 ES_BUFFER_SIZE = 1000
+
+OLDEST_ALLOWED_PERIOD = 2018


### PR DESCRIPTION
This PR adds a pipeline that filters out news based on publish year. If that info's not available, update year is used instead. In order to easily parse out years from timestamps of many formats, a dependency has been added: [dateutil](https://pypi.org/project/python-dateutil/).